### PR TITLE
2fa code to copy instead only scan QR.

### DIFF
--- a/accepted/0000-2fa-code.md
+++ b/accepted/0000-2fa-code.md
@@ -1,0 +1,27 @@
+# Add 2FA code instead only QR code.
+
+## Summary
+
+Show TOTP code and QR code. When someone has broken camera or wan't to add TOTP to application.
+
+## Motivation
+
+I think is few lines in code and it will help people with adding 2FA to account.
+
+## Detailed Explanation
+
+When 2FA QR code is displayed then show below TOTP code to copy
+
+## Rationale and Alternatives
+
+NONE
+
+## Implementation
+
+Only last part of adding 2FA to account
+
+## Prior Art
+
+Most sites has ablility to copy code instead only scan QR code
+
+## Unresolved Questions and Bikeshedding


### PR DESCRIPTION
# What / Why
Display 2FA code to copy instead only QR code to scan. It will help to add TOTP/2FA to application when camera is broken.

## References
n/a
