### PR TITLE
feat: added new issue template for RRFC's

### DIFF
--- a/.github/ISSUE_TEMPLATE/rrfc.md
+++ b/.github/ISSUE_TEMPLATE/rrfc.md
@@ -1,0 +1,40 @@
+---
+name: RRFC
+about: Requesting Request For Comment
+title: '[RRFC] <title>'
+assignees:
+labels:
+---
+
+<!--
+# Before Opening Please...
+- [ ] Search for an existing/duplicate RRFC which might be relevant to your RRFC
+-->
+## Motivation ("The Why")
+<!-- Examples
+Let us know why or how you thought of this idea.
+-->
+
+### Example
+<!-- Examples
+An example of what your idea might or could do for you and others.
+-->
+
+### How
+#### Current Behaviour
+<!-- Examples
+What is currently happening, which doesn't take care of your situation/context?
+-->
+
+#### Desired Behaviour
+<!-- Examples
+How would you like things to generally work to cover your situation/context?
+-->
+
+### References
+<!-- Examples
+* Related/Reference to #0
+* Depends on #0
+* Blocked by #0
+-->
+* n/a


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
Currently this repository is inheriting it's issue template from https://github.com/npm/open-source-project-boilerplate which has templates mostly specific to "standard" open source projects with code in them. This project is a little different in that issues are almost exclusively RRFC's. The templates for this repository should reflect that.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* closes #88 
