### PR TITLE
RFC: Add publish confirmation prompt

### DIFF
--- a/accepted/0000-publish-prompt.md
+++ b/accepted/0000-publish-prompt.md
@@ -1,4 +1,4 @@
-# Publish prompt
+# Publish confirmation prompt
 
 ## Summary
 
@@ -18,7 +18,7 @@ A broader population of package authors can benefit from this UX if we formalize
 
 ### Feedback from the discussion around this RFC
 
-- Should be implemented behind an opt-in/experimental flag for npm@7
+- Should be implemented behind an opt-in flag for npm@7
 - Non-TTY environments should skip the prompt.
 
 ## Alternatives
@@ -27,10 +27,10 @@ A broader population of package authors can benefit from this UX if we formalize
 
 ## Implementation
 
-Prompts the user for confirmation when using the experimental flag:
+Prompts the user for confirmation when using the opt-in flag:
 
 ```sh
-$ npm publish --experimental-publish-confirmation
+$ npm publish --publish-confirmation
 
 npm notice
 npm notice 📦  disparity@3.0.0
@@ -60,7 +60,7 @@ Do you wish to proceed? [y/N]
 The user can also provide a `--yes` option that can skip the prompt and keep current behavior:
 
 ```
-$ npm publish --experimental-publish-confirmation --yes
+$ npm publish --publish-confirmation --yes
 ```
 
 ## Prior Art

--- a/accepted/0000-publish-prompt.md
+++ b/accepted/0000-publish-prompt.md
@@ -16,17 +16,21 @@ Currently "publish" has a very nice **unintended UX** for users with 2FA enabled
 
 A broader population of package authors can benefit from this UX if we formalize it. Allowing for review of contents and cancelation of package publishing.
 
+### Feedback from the discussion around this RFC
+
+- Should be implemented behind an opt-in/experimental flag for npm@7
+- Non-TTY environments should skip the prompt.
+
 ## Alternatives
 
-1. Not change it, just keep the current behavior?
-2. Implement it behind an _opt-in_ config option
+1. Not implement it, keep the current behavior.
 
 ## Implementation
 
-This is a breaking change from the current `npm publish` behavior, it would prompt the user for confirmation:
+Prompts the user for confirmation when using the experimental flag:
 
 ```sh
-$ npm publish
+$ npm publish --experimental-publish-confirmation
 
 npm notice
 npm notice 📦  disparity@3.0.0
@@ -56,13 +60,9 @@ Do you wish to proceed? [y/N]
 The user can also provide a `--yes` option that can skip the prompt and keep current behavior:
 
 ```
-$ npm publish --yes
+$ npm publish --experimental-publish-confirmation --yes
 ```
 
 ## Prior Art
 
-Currently `npm publish` will automatically publish the tarball to the registry in case the user does not have OTP enabled.
-
-## Unresolved Questions and Bikeshedding
-
-- Could be tricky to handle publishing of multiple packages in the context of a **workspace** environment.
+Currently `npm publish` will automatically publish the tarball to the registry without any confirmation prompt in case the user does not have OTP enabled.

--- a/accepted/0000-publish-prompt.md
+++ b/accepted/0000-publish-prompt.md
@@ -1,0 +1,67 @@
+# Publish prompt
+
+## Summary
+
+Publishing a package should prompt a confirmation prompt, allowing users to validate their package info before uploading their package tarball.
+
+## Motivation
+
+Breaking the prompt into a two-step operation allows for a validation of contents prior to uploading the package but it also enable new possibilities such as printing warnings promotting 2FA adoption, etc.
+
+## Detailed Explanation and Rationale
+
+`npm publish` should ask for a confirmation prompt prior to uploading the package tarball.
+
+Currently "publish" has a very nice behavior for users that have 2FA enabled, one in which it stops the publish process in order to ask for the OTP code, allowing for a review of the file contents prior to uploading the tarball file.
+
+It would be very nice to expand that "review" 
+
+## Alternatives
+
+Not change it, just keep the current behavior?
+
+## Implementation
+
+This is a breaking change from the current `npm publish` behavior, it would prompt the user for confirmation:
+
+```sh
+$ npm publish
+
+npm notice
+npm notice 📦  disparity@3.0.0
+npm notice === Tarball Contents ===
+npm notice 183B  bin/disparity
+npm notice 2.1kB disparity-cli.js
+npm notice 4.3kB disparity.js
+npm notice 999B  package.json
+npm notice 875B  CHANGELOG.md
+npm notice 1.1kB LICENSE.md
+npm notice 3.7kB README.md
+npm notice === Tarball Details ===
+npm notice name:          disparity
+npm notice version:       3.0.0
+npm notice filename:      disparity-3.0.0.tgz
+npm notice package size:  5.2 kB
+npm notice unpacked size: 13.3 kB
+npm notice shasum:        4344ee202484ab134227913a3af6f4a0ae5f0a59
+npm notice integrity:     sha512-NAItmPQyt6dya[...]m5N3kfPPJYj0w==
+npm notice total files:   7
+npm notice
+
+This operation will publish your package to the npm registry.
+Do you wish to proceed? [y/N]
+```
+
+The user can also provide a `--yes` option that can skip the prompt and keep current behavior:
+
+```
+$ npm publish --yes
+```
+
+## Prior Art
+
+Currently `npm publish` will automatically publish the tarball to the registry in case the user does not have OTP enabled.
+
+## Unresolved Questions and Bikeshedding
+
+TBD

--- a/accepted/0000-publish-prompt.md
+++ b/accepted/0000-publish-prompt.md
@@ -6,19 +6,20 @@ Publishing a package should prompt a confirmation prompt, allowing users to vali
 
 ## Motivation
 
-Breaking the prompt into a two-step operation allows for a validation of contents prior to uploading the package but it also enable new possibilities such as printing warnings promotting 2FA adoption, etc.
+Breaking the prompt into a two-step operation allows for a validation of contents prior to uploading the package.
 
 ## Detailed Explanation and Rationale
 
 `npm publish` should ask for a confirmation prompt prior to uploading the package tarball.
 
-Currently "publish" has a very nice behavior for users that have 2FA enabled, one in which it stops the publish process in order to ask for the OTP code, allowing for a review of the file contents prior to uploading the tarball file.
+Currently "publish" has a very nice **unintended UX** for users with 2FA enabled, in which it stops the publish process in order to ask for the OTP code, allowing for a review of the file contents (and even cancelling the process altogether) prior to uploading the tarball file.
 
-It would be very nice to expand that "review" 
+A broader population of package authors can benefit from this UX if we formalize it. Allowing for review of contents and cancelation of package publishing.
 
 ## Alternatives
 
-Not change it, just keep the current behavior?
+1. Not change it, just keep the current behavior?
+2. Implement it behind an _opt-in_ config option
 
 ## Implementation
 
@@ -64,4 +65,4 @@ Currently `npm publish` will automatically publish the tarball to the registry i
 
 ## Unresolved Questions and Bikeshedding
 
-TBD
+- Could be tricky to handle publishing of multiple packages in the context of a **workspace** environment.


### PR DESCRIPTION
`npm publish` should have a confirmation prompt in order to provide a chance for users to review the package contents, similar to how 2FA-enabled users are able to review the contents prior to inputting their OTP.

[See RFC](https://github.com/npm/rfcs/blob/8129a02baa03d1bd4f0f9f9ee98d3f7de0b4e0b6/accepted/0000-publish-prompt.md)

/cc @mikemimik 