### PR TITLE
Clarify/Outline the RFC Withdrawal Process & Amendment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# npm RFC Process
+# RFC Process
 
 This document describes the RFC process for the [npm
-CLI](https://github.com/npm/cli), and provides a way for the [Community & Open Source Team]() and the
+CLI](https://github.com/npm/cli), and provides a way for the [Community & Open Source Team](https://github.com/orgs/npm/teams/cli-team) and the
 wider community to have discussions about the features and direction of the
 package manager! It is based on [the WeAllJS RFC process](https://wealljs.org/rfc-process) and the [Rust RFC process](https://github.com/rust-lang/rfcs), and, by extension, the [Yarn RFC process](https://github.com/yarnpkg/rfcs)
 
 ## What's an RFC?
 
-The name itself is a reference to the IETF's Request For Comments process, and
+The name itself is a reference to the **IETF's Request For Comments** process, and
 basically involves a document or series of documents which are drafted,
 reviewed, and eventually ratified (approved) by the npm team through discussion
 among those interested, both within and outside of the npm team.
@@ -78,11 +78,22 @@ integration into the CLI may also be deferred to a later date, or a later
 semver-major CLI release, at the npm collaborators' discretion. All the RFC does
 is communicate the team's consensus to accept a change.
 
+### Implementation
+
 When the changes described in an RFC have been implemented and merged into the
 relevant repository (and thus, due to be released), the corresponding RFC will
 be moved from `accepted/` to `implemented/`. If you'd like to implement an
 accepted RFC, please make a PR in the appropriate repo and mention the RFC in
-the PR. Feel free to do this even for work-in-progress code!
+the PR. Feel free to do this even for work-in-progress code.
+
+### Withdrawal
+
+From time to time npm collaborators will review RFCs awaiting implementation to
+ensure their accuracy and relevance. In cases where a previously ratified RFC is
+deemed to no longer be a viable candidate for implementation, an [**amendment
+section**](withdrawn/0000-template.md) will be added **to the top** of the
+document outlining the reason for repeal and subsequently moved to the
+`withdrawn/` section of this repository.
 
 ## How do I change an RFC after ratification?
 

--- a/withdrawn/0000-template.md
+++ b/withdrawn/0000-template.md
@@ -1,0 +1,9 @@
+# Withdrawal Amendment
+
+{{This section is required for withdrawing a previously ratified RFC. Provide as much detail as possible as to why the originally drafted proposal no longer should be considered for implementation}}
+
+## Relevant Resources
+
+{{Optional section to link relevant resources and discussions relevant to this RFCs withdrawal}}
+
+{{Original RFC}}


### PR DESCRIPTION
We need some clarification around how we opt-out/rescind/withdraw previously *accepted* RFCs that may become outdated or are succeeded before ever being *implemented*.
