### PR TITLE
Add registry info to RFC 0028

### DIFF
--- a/accepted/0028-publish-prompt.md
+++ b/accepted/0028-publish-prompt.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Publishing a package should prompt a confirmation prompt, allowing users to validate their package info before uploading their package tarball.
+Publishing a package should prompt a confirmation prompt, allowing users to validate their package info and the target registry before uploading their package tarball.
 
 ## Motivation
 
@@ -53,7 +53,7 @@ npm notice integrity:     sha512-NAItmPQyt6dya[...]m5N3kfPPJYj0w==
 npm notice total files:   7
 npm notice
 
-This operation will publish your package to the npm registry.
+This operation will publish your package to the npm registry at https://registry.npmjs.org.
 Do you wish to proceed? [y/N]
 ```
 


### PR DESCRIPTION
# What / Why
Adapted the summary and implementation section of **RFC 0028** to clarify that the prompt will explicitly display the registry the package will be published to. 

## References
Requested via [#191](https://github.com/npm/rfcs/issues/191#issuecomment-681022792).