### PR TITLE
RFC: audit assertions

### DIFF
--- a/accepted/0028-npm-license.md
+++ b/accepted/0028-npm-license.md
@@ -109,12 +109,7 @@ Open-source tooling:
 
 ## Unresolved Questions and Bikeshedding
 
-- command naming
 - property naming
 - package.json/audit.json/both
-- interactive triage
-  - should it exist?
-  - what's the DX?
-- log levels of different parts of the proposal
 
 {{THIS SECTION SHOULD BE REMOVED BEFORE RATIFICATION}}

--- a/accepted/0028-npm-license.md
+++ b/accepted/0028-npm-license.md
@@ -14,6 +14,26 @@ Given that this is something that a non-trivial number of users care about _and_
 
 ## Detailed Explanation
 
+### Dependency implementation:  
+
+- Add a dependency on [licensee](https://www.npmjs.com/package/licensee)
+- Follow the licensee API, with some modifications
+  - CLI configuration and commands are aliased to `npm audit license <flags/arguments>` rather than the `licensee` command
+  - JSON configuration can either exist in `package.json` under the `audit` property (as an object) in a `licenses` property (as an object), with the same API **or** under the `licenses` (as an object) property in a file named `audit.json`
+    - one of the two should take precident over the other if duplication occurs. My preference would be package.json but I can understand why others would disagree and do not hold this opinion strongly.
+
+### Additional commands and flags:
+
+Since this proposal moves `npm audit` into a wholistic auditing suite rather than just focusing on security, there would need to be additional commands and flags to limit specific features of audit in addition to expanding the scope of the existing flags:
+
+  - `npm audit security` should be added for consistency. This would replicate the current `npm audit` behavior, auditing dependencies for known security vulnerabilities.
+  - `npm audit` would now run both `npm audit security` and `npm audit license`
+  - `--no-audit` now blocks `npm audit` which encompasses all audits
+  - `--no-audit-security` should block **only security auditing**
+  - `--no-audit-license` should block **only license auditing**
+
+
+<!-- Old "Detailed Explanation" - saved for context while drafting.
 - It should be possible to get a full report of the licenses from all dependencies.
   - This should be runnable from a single command: `npm audit licenses`
     - Offline (default)
@@ -44,6 +64,7 @@ Given that this is something that a non-trivial number of users care about _and_
       - This report should collect all licenses via the `license` properties from `package.json` files in `node_modules`, filtering out any licenses that are in `allow` and  `block` in addition to any licenses or modules in `ignore`, and provide the user the option to `allow`, `block`, or `ignore` the license, one by one.
     - Online (`--online`)
       - This report should collect all licenses via the `license` properties from `package.json` files from a resolved dependency tree without needing the modules on disk, filtering out any licenses that are in `allow` and  `block` in addition to any licenses or modules in `ignore`, and provide the user the option to `allow`, `block`, or `ignore` the license, one by one.
+-->
 
 ## Rationale and Alternatives
 
@@ -52,7 +73,7 @@ There are a wide array of tools in the ecosystem that have been built to paper o
 Alternatives considered:
 
 - Distinct command within the CLI, outside of audit (`npm license` or `npm compliance`).
-  - Discarded this as it would potentially create further fragmentation where it's potentially unnecessary.
+  - Discarded this as it would potentially create further fragmentation of the npm CLI's user-facing components where it's potentially unnecessary. Further, since this feature only _adds_ to `npm audit`, it should not detract from the experience of those already relying on `npm audit` for security functionality until they opt-in to using licensing functionality.
 - Leave it to the ecosystem.
   - This has been the state of the world for about a decade, and there's still been no excessively positive tooling that's come up and solved all the problems that exist in this space while achieving widespread adoption.
 
@@ -74,7 +95,6 @@ Paid tooling:
 Open-source tooling:
 
 - https://www.npmjs.com/package/license-checker - relatively widely used and similar-ish to what's proposed. Also a requirable module.
-- https://www.npmjs.com/package/licensee - similar-ish to what's proposed. Potentially already used by npm?
 - https://www.npmjs.com/package/license-report - similar-ish to what's proposed.
 - https://www.npmjs.com/package/nlf - similar-ish to what's proposed. Also a requirable module.
 - https://www.npmjs.com/package/npm-license - similar-ish to what's proposed.

--- a/accepted/0028-npm-license.md
+++ b/accepted/0028-npm-license.md
@@ -1,0 +1,93 @@
+# Add license reporting to npm
+
+## Summary
+
+It should be possible to get a full report of the licenses from all dependencies. This report should include the license as defined in `package.json` in addition to including a path to any relevant `LICENSE`-ish files within the project. Additionally, end-users should be able to have an allowlist and blocklist of "acceptable" licenses, a way to allow modules with licenses outside of that list that have been triaged, and have a way to install such a list.
+
+## Motivation
+
+{{Why are we doing this? What pain points does this resolve? What use cases does it support? What is the expected outcome? Use real, concrete examples to make your case!}}
+
+License reporting is something that there seems to be a non-trivial amount of ecosystem tooling around - largely built by folks at large corps or by companies that focus on dependencies as a core part of their business in some way - without having any kind of official recognition beyond the "license" property being displayed on the package view of npmjs.com.
+
+Given that this is something that a non-trivial number of users care about _and_ that the state of the ecosystem is relatively fragmented, there's an opportunity to include license tooling as a first-class tool within the ecosystem and both help incrementally improve the ecosystem's awareness/practices around this in addtion to providing blessed built-in tooling that can help resolve a problem the ecosystem is pretty consistently having to build their own tooling for.
+
+## Detailed Explanation
+
+- It should be possible to get a full report of the licenses from all dependencies.
+  - This should be runnable from a single command: `npm audit licenses`
+    - Offline (default)
+      - This report should collect all licenses via the `license` properties from `package.json` files in `node_modules`.
+    - Online (`--online`)
+      - This report should have an `--online` mode that will resolve the dependency tree and fetch the entire dependency tree's licenses without needing the modules on disk.
+    - Output
+      - This report should default to a pretty printed human-readable version.
+      - This report should be able to be output as JSON with a `--json` flag.
+- It should be possible to define a set of allowed, blocked, and ignored licenses
+  - Location
+    - This should be able to be defined both in `package.json` or something like `audit.json`.
+  - Contents
+    - These lists should an be in a `licenses` object with three properties - `allow` (array), `block` (array), and `ignore` (object).
+      - If in `package.json`, `licenses` should be a subproperty of `audit`.
+      - If in `audit.json`, `licenses` should be a top level property.
+      - In `licenses`, `allow` should be an array of values that would _ideally_ be SPDX License Identifiers or SPDX License Expressions but in reality will not end up always being that.
+      - In `licenses`, `block` should be an array of values that would _ideally_ be SPDX License Identifiers or SPDX License Expressions but in reality will not end up always being that.
+      - In `licenses`, `ignore` should be an object with two properties - `licenses` and `modules`.
+        - `licenses` is a list of license values (parsed from `license` in dependencies' `package.json`) to _ignore_ from any kind of checking.
+        - `modules` is a list of modules (parsed from `name` in dependencies' `package.json`) to _ignore_ from any kind of checking.
+  - Behavior on `npm install`
+    - If a `block` property exists, npm should not install any modules on-disk that have a value in `license` that matches any of the values in `block`.
+    - All blocked modules and the path they were introduced through should be reported as an `error` or `warn`.
+- It should be possible to triage licenses that are on disk (in `node_modules`) or would be resolved in the dependency tree
+  - This should be accomplished through `npm audit licenses triage`
+    - Offline (default)
+      - This report should collect all licenses via the `license` properties from `package.json` files in `node_modules`, filtering out any licenses that are in `allow` and  `block` in addition to any licenses or modules in `ignore`, and provide the user the option to `allow`, `block`, or `ignore` the license, one by one.
+    - Online (`--online`)
+      - This report should collect all licenses via the `license` properties from `package.json` files from a resolved dependency tree without needing the modules on disk, filtering out any licenses that are in `allow` and  `block` in addition to any licenses or modules in `ignore`, and provide the user the option to `allow`, `block`, or `ignore` the license, one by one.
+
+## Rationale and Alternatives
+
+There are a wide array of tools in the ecosystem that have been built to paper over the lack of license tooling in npm and the JavaScript ecosystem. There's clearly a desire/need for license tooling, and including it directly in npm would help drive both improved experiences for developers and overall best practices.
+
+Alternatives considered:
+
+- Distinct command within the CLI, outside of audit (`npm license` or `npm compliance`).
+  - Discarded this as it would potentially create further fragmentation where it's potentially unnecessary.
+- Leave it to the ecosystem.
+  - This has been the state of the world for about a decade, and there's still been no excessively positive tooling that's come up and solved all the problems that exist in this space while achieving widespread adoption.
+
+## Implementation
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+{{THIS SECTION IS REQUIRED FOR RATIFICATION -- you can skip it if you don't know the technical details when first submitting the proposal, but it must be there before it's accepted}}
+
+## Prior Art
+
+Paid tooling:
+
+- https://fossa.com/ - OSS license checking as service. Gives the service for free to impactful OSS projects.
+- https://help.sonatype.com/repomanager3/formats/npm-registry#npmRegistry-npmaudit - Private registry product extension. Enterprise use case, relatively widely used by megacorps.
+- https://jfrog.com/xray/ - Private registry product extension. Enterprise use case, relatively widely used by megacorps.
+- https://docs.nodesource.com/ncmv2/docs#compliance - Extension of the public registry as an Electron app/web service. Was killed pre-acquisition. Company publicly stated they had relatively large enterprise customers.
+
+Open-source tooling:
+
+- https://www.npmjs.com/package/license-checker - relatively widely used and similar-ish to what's proposed. Also a requirable module.
+- https://www.npmjs.com/package/licensee - similar-ish to what's proposed. Potentially already used by npm?
+- https://www.npmjs.com/package/license-report - similar-ish to what's proposed.
+- https://www.npmjs.com/package/nlf - similar-ish to what's proposed. Also a requirable module.
+- https://www.npmjs.com/package/npm-license - similar-ish to what's proposed.
+- https://www.npmjs.com/package/delice - similar-ish to what's proposed.
+
+## Unresolved Questions and Bikeshedding
+
+- command naming
+- property naming
+- package.json/audit.json/both
+- interactive triage
+  - should it exist?
+  - what's the DX?
+- log levels of different parts of the proposal
+
+{{THIS SECTION SHOULD BE REMOVED BEFORE RATIFICATION}}

--- a/accepted/0028-npm-license.md
+++ b/accepted/0028-npm-license.md
@@ -32,6 +32,13 @@ Since this proposal moves `npm audit` into a wholistic auditing suite rather tha
   - `--no-audit-security` should block **only security auditing**
   - `--no-audit-license` should block **only license auditing**
 
+On action if a module doesn't have a compatible license:
+
+- the `npm audit fix` command *should* search for and implement a replacement if at all possible given the list of allowed/blocked licenses and semver ranges
+- the `npm audit fix --force` command *should* search for and force a replacement if at all possible given the list of allowed/blocked licenses and semver ranges
+- the `npm audit` command *should* report license failures and which versions would "fix" licenses that are blocked but have already been resolved.
+- the audit report on `npm install` should report how many modules do not comply with license requirements
+
 
 <!-- Old "Detailed Explanation" - saved for context while drafting.
 - It should be possible to get a full report of the licenses from all dependencies.

--- a/accepted/9999-npm-audit-assertions.md
+++ b/accepted/9999-npm-audit-assertions.md
@@ -1,0 +1,64 @@
+# `npm audit` assertions
+
+## Summary
+
+A mechanism for module maintainers to assert that their modules are not impacted by advisories.
+
+```
+npm auidit assert --module=<module-name> --id=<advisory identifier> --impactful=<boolean>
+```
+
+## Motivation
+
+It's relatively common that `npm audit` creates a painful experience for maintainers of transitive dependencies and for end-users, with a seemingly high likelihood to have a disproportionately large negative impact on beginners who don't actually know what's happening.
+
+Further, the amount of noise that `npm audit` generates from transitive dependencies that rely on a "vulnerable" module where there is no world in which the "vulnerability" can be exploited leads to people ignoring `npm audit` rather than leveraging it to actually address vulnerabilities.
+
+Enabling maintainers of dependencies - most importantly, dependencies that are most often transitive - to assert that their dependencies are not impacted by known vulnerabilities is a way to dramatically reduce the amount of pain that `npm audit` creates.
+
+Further, this creates an additional cascading signal of _validity_ when the maintainers of a transitive dependency mark the advisory as impactful. As maintainers make assertions, we get more context about the impact of advisories across the ecosytem, which - if surfaced to end-users through `npm audit` - helps provide more context to make an informted decision about how to address advisories that they're seeing.
+
+## Detailed Explanation
+
+- `npm audit assert` will be added with the following arguments:
+  - `--module=<module-name>` where `<module-name>` is the name of the module having an assertion made. If I was a maintainer of `fastify` and wanted to make an assertion about it, I'd use `--module=fastify`.
+  - `--id=<advisory identifier>` is the identifier of the advisory that impacts my module that I'm making an assertion about. As a hypothetical maintainer of `fastify` wanting to make to make an assertion about the npm advisory `1726`, I'd use `--id=1726`. This also potentially allows for future expansion into other identifiers. For example, if I wanted to make an assertion about `CVE-2021-28562` advisory, I'd use `--id=CVE-2021-28562`. I'd love to see namespacing, like `npm-1726`, but I could understand why people might be against that.
+  - `--impactful=<boolean>` this should just be `true` or `false`. If it's `true`, then an assertion is made that the advisory is impactful to the module passed to `--module`. If it's `false`, then an assertion is made that the advisory is not impactful to the module passed to `--module`.
+- `npm audit` will need to be updated to both consume additional data and provide additional filters.
+  - by default, `npm audit` should
+    - surface advisories that have no assertions or `--impactful=true` assertions
+    - ignore advisories that have `--impactful=false` assertions, **presuming** there are no alternative paths to the advisories that have no assertions or `--impactful=true` assertions
+  - the `--assertions` flag should be added
+    - it should take the following values:
+      - `only`: only show the advisories that have have assertions, `true` or `false`
+      - `only-true`: only show the advisories that have `--impactful=true` assertions
+      - `only-false`: only show the advisories that have `--impactful=false` assertions
+      - `unfiltered`: show all the advisories, regardless of whether they have assertions, `true` or `false`
+    - these should probably be sent to the server to be filtered server-side and enable smaller responses.
+  - the UI should also display if an assertion has been made, and what that assertion is.
+  - `--json` should include assertions, if any exist.
+- They adition of `npm audit assert` will require some kind of change to the server that serves the information that powers `npm audit`. Specifically, this information will need to be acceptted when `npm audit assert` is run, and returned with `npm audit` information. Additionally, depending on how this is implemented, this might reduce the number of requests made and data returned to end-users. Specifically, if the CLI assumes by default that users want to ignore vulnerabilities that have been marked as `--impactful=false` by transitive (or direct) dependencies **and** that is sent to the server, the server can return only what's needed rathter than the full set of data.
+
+## Rationale and Alternatives
+
+- Do nothing: The current state of the world that has caused [pain](https://overreacted.io/npm-audit-broken-by-design/).
+- Allow reporters to mark which modules are impacted: not really scalable, especially since reporters won't be experts in the same way that maintainers are.
+- Do something in a neutral space, run by an independent organization: There's no reason this couldn't eventually be implemented under this API. It is contingent on that work being done and being successfully adopted by others. That shouldn't necessarily prevent us from implementing this and mapping it over to that later.
+
+This solution both begins to address the problem that exists presently, doesn't exclude potential external solutions/patterns from being adopted in the future, and allows an implementation to be implemented with _relative_ haste.
+
+## Implementation
+
+{{Give a high-level overview of implementation requirements and concerns. Be specific about areas of code that need to change, and what their potential effects are. Discuss which repositories and sub-components will be affected, and what its overall code effect might be.}}
+
+{{THIS SECTION IS REQUIRED FOR RATIFICATION -- you can skip it if you don't know the technical details when first submitting the proposal, but it must be there before it's accepted}}
+
+## Prior Art
+
+I've not seen other tools doing this, but I would be surprised if there's not prior art. After some searching, I can't find anthing.
+
+## Unresolved Questions and Bikeshedding
+
+- The potential values for the `--assertions` filter on `npm audit` could probably be bikeshedded a bit. I'm unattached to the names.
+- UI in `npm audit` outpit could be bikeshedded as well.
+- It would be cool if there was the ability to have multiple maintainers run `npm audit assert` for a given `id` and surface that _multiple_ people signed off on the assertion as a way to begin combatting some forms of social engineering attacks we've seen in the past, but that might be too complex for now.


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
There's been an interest [expressed](https://overreacted.io/npm-audit-broken-by-design/) in the ecosystem of having some form of counterclaim for advisories surfaced by `npm audit`. There's been some discussion of a potential counterclaim mechanism for some time, but I've not seen a solution proposed.

The intent of this RFC is to do that - propose a solution. I *do not* expect that this solution will go through unanimously and unchanged, but I'd like to get something up that can be talked about and addressed both by the ecosystem and by those thinking about Security in the registry and CLI. If the answer to this is "no" with some set of reasons, that's a perfectly reasonable outcome.

I'm particularly interested in feedback from *security researchers* on why this is / is not a good solution, and what alternatives might be implemented or what tweaks might be made to make it a better solution. I appreciate feedback from developers who care, but also want folks to keep in mind that this has the potential for massively negative impact should a vulnerability get through that should not get through.
