### PR TITLE
chore: add private flag to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "npm CLI rfcs",
   "main": "index.js",
+  "private": true,
   "scripts": {
     "create-agenda": "node ./scripts/create-agenda.js"
   },


### PR DESCRIPTION
This will prevent us from accidentally trying to publish this non-package, and will allow us to programmatically differentiate between our package and non-package repos.