### PR TITLE
add "obey user specifier" RFC

### DIFF
--- a/accepted/0000-obey-user-specifier.md
+++ b/accepted/0000-obey-user-specifier.md
@@ -1,0 +1,33 @@
+# obey the user's specifier
+
+## Summary
+
+When I type `npm install package@specifier`, a normalized `specifier` is what should be saved to `package.json`, no more, no less.
+
+## Motivation
+
+Currently, if i type `npm install --save-dev eslint@=8.0.0 other`, it installs v8.8.0, but saves `^8.8.0` to `package.json` (with the default `save-prefix` of `^`). (note: i'm intentionally not using `--save-exact` here, because i want `other` to install using the default `save-prefix`).
+
+When no `@version` is provided, or when a dist-tag is provided, it makes *perfect* sense to resolve that to a version, and save it with `save-prefix`. However, when I've provided a version range - `=1.2.3`, `~1.2.3`, `>= 1.2` - I know what I want, I’ve explicitly told npm I want it, and npm should obey my wishes not just in the reification in `node_modules` (which I believe it does), but also in what it saves to `package.json`.
+
+## Detailed Explanation
+
+When a non-dist-tag version range is provided, and a range signifier is included, persist it to `package.json`.
+
+## Rationale and Alternatives
+
+1. split my command into two - `npm install --save-dev --save-exact eslint@=8.8.0 && npm install --save-dev other`
+1. manually edit my `package.json` afterwards (this is what i currently do)
+1. weep in the rain, alone again, in front of my telephone box
+
+## Implementation
+
+I assume this information which is currently discarded or misplaced inside Arborist would need to be persisted.
+
+## Prior Art
+
+Generally speaking, tools all do what you explicitly ask them to do :-) it’d be nice if npm did too.
+
+## Unresolved Questions and Bikeshedding
+
+Would this be considered a bugfix or a breaking change? If a breaking change, how could we ship it as a semver-minor where i could set a persistent config in my user npmrc?


### PR DESCRIPTION
When I type `npm install package@specifier`, a normalized `specifier` is what should be saved to `package.json`, no more, no less.

## Motivation

Currently, if i type `npm install --save-dev eslint@=8.0.0 other`, it installs v8.8.0, but saves `^8.8.0` to `package.json` (with the default `save-prefix` of `^`). (note: i'm intentionally not using `--save-exact` here, because i want `other` to install using the default `save-prefix`).

When no `@version` is provided, or when a dist-tag is provided, it makes *perfect* sense to resolve that to a version, and save it with `save-prefix`. However, when I've provided a version range - `=1.2.3`, `~1.2.3`, `>= 1.2` - I know what I want, I’ve explicitly told npm I want it, and npm should obey my wishes not just in the reification in `node_modules` (which I believe it does), but also in what it saves to `package.json`.