### PR TITLE
fix!: align to npm 11 node engine range

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^20.17.0 || >=22.9.0"
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",


### PR DESCRIPTION
This PR updates the Node.js engine requirement to align with npm 11.

## Changes
- Updated `engines.node` in package.json to `^20.17.0 || >=22.9.0`

## Breaking Change
This is a breaking change as it drops support for Node.js versions outside the specified range.

**New requirement:** Node.js `^20.17.0 || >=22.9.0`