### PR TITLE
RFC: propose RFC for optional icon field in package.json

### DIFF
--- a/icon.md
+++ b/icon.md
@@ -11,7 +11,7 @@ especially in large plugin or library ecosystems.
 
 ## Proposed Solution
 
-This RFC proposes adding an optional `icon` field to `package.json`.
+This RFC proposes adding an optional `icon` field to `package.json`
 This field allows package authors to explicitly specify a URL to an image
 that represents the package.
 


### PR DESCRIPTION
<!-- What / Why -->
This PR proposes to add an icon field in the package.json file, which shall enable image availability on the npm website. On the npm website, most packages do not have icons, which makes it difficult for users to navigate or find packages easily. Adding this field to package.json will expose it through the npm API and help in displaying images.


## References
Related to npm/cli#8878
